### PR TITLE
Support partition key in type: timestamp with time zone

### DIFF
--- a/internal/infra/postgresql/column.go
+++ b/internal/infra/postgresql/column.go
@@ -39,6 +39,8 @@ func (p Postgres) GetColumnDataType(schema, table, column string) (ColumnType, e
 		return DateTime, nil
 	case "timestamp without time zone":
 		return DateTime, nil
+	case "timestamp with time zone":
+		return DateTime, nil
 	case "uuid":
 		return UUID, nil
 	default:

--- a/internal/infra/postgresql/column_internal_test.go
+++ b/internal/infra/postgresql/column_internal_test.go
@@ -48,6 +48,11 @@ func TestGetColumn(t *testing.T) {
 			DateTime,
 		},
 		{
+			"Date time with time zone",
+			"timestamp with time zone",
+			DateTime,
+		},
+		{
 			"UUID",
 			"uuid",
 			UUID,


### PR DESCRIPTION
Accept the "timestamp with time zone" date type as partition key.