### PR TITLE
Do not automatically provision partitions in the past

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ PPM will process all referenced partitions and exit with a non-zero code if it d
 
 **Features**:
 
-- Creation of upcoming partitions
+- Creation of upcoming partitions (as well as outdated partitions if requested)
 - Delete (or detach) outdated partitions
 - Check partitions configuration
 
@@ -215,7 +215,7 @@ The primary commands include:
 
 - `validate`: Validates the partition configuration file
 - `run check`: Checks if partitions match the expected configuration. This is useful for detecting incorrect partitions
-- `run provisioning`: Creates future partitions
+- `run provisioning`: Creates future partitions (as well as outdated partitions if `provisionRetentionPartitions` is true)
 - `run cleanup`: Removes (or detach) outdated partitions
 - `run all`: Execute provisioning, cleanup, and check commands sequentially
 
@@ -239,15 +239,16 @@ Configuration could be defined in `postgresql-partition-manager.yaml` or environ
 
 Partition object:
 
-| Parameter      | Description                                          | Default |
-| -------------- | ---------------------------------------------------- | ------- |
-| column         | Column used for partitioning                         |         |
-| interval       | Partitioning interval (`daily`, `weekly`, `monthly`, `quarterly` or `yearly`) |         |
-| preProvisioned | Number of partitions to create in advance            |         |
-| retention      | Number of partitions to retain                       |         |
-| schema         | PostgreSQL schema                                    |         |
-| table          | Table to be partitioned                              |         |
-| cleanupPolicy  | `detach` refers to detaching only the partition while `drop` refers to both detaching and dropping it |         |
+| Parameter                    | Description                                                                                           | Default |
+|------------------------------|-------------------------------------------------------------------------------------------------------|---------|
+| column                       | Column used for partitioning                                                                          |         |
+| interval                     | Partitioning interval (`daily`, `weekly`, `monthly`, `quarterly` or `yearly`)                         |         |
+| preProvisioned               | Number of partitions to create in advance                                                             |         |
+| retention                    | Number of partitions to retain                                                                        |         |
+| schema                       | PostgreSQL schema                                                                                     |         |
+| table                        | Table to be partitioned                                                                               |         |
+| cleanupPolicy                | `detach` refers to detaching only the partition while `drop` refers to both detaching and dropping it |         |
+| provisionRetentionPartitions | forces the creation of outdated partitions compatible with the retention period                       | false   |
 
 See the [full configuration file](configs/postgresql-partition-manager/postgresql-partition-manager.yaml).
 

--- a/configs/postgresql-partition-manager/postgresql-partition-manager.yaml
+++ b/configs/postgresql-partition-manager/postgresql-partition-manager.yaml
@@ -31,3 +31,4 @@
 #     retention: 30
 #     preProvisioned: 7
 #     cleanupPolicy: drop
+#     provisionRetentionPartitions: false

--- a/internal/infra/partition/configuration.go
+++ b/internal/infra/partition/configuration.go
@@ -15,13 +15,14 @@ const (
 )
 
 type Configuration struct {
-	Schema         string        `mapstructure:"schema" validate:"required"`
-	Table          string        `mapstructure:"table" validate:"required"`
-	PartitionKey   string        `mapstructure:"partitionKey" validate:"required"`
-	Interval       Interval      `mapstructure:"interval" validate:"required,oneof=daily weekly monthly quarterly yearly"`
-	Retention      int           `mapstructure:"retention" validate:"required,gt=0"`
-	PreProvisioned int           `mapstructure:"preProvisioned" validate:"required,gt=0"`
-	CleanupPolicy  CleanupPolicy `mapstructure:"cleanupPolicy" validate:"required,oneof=drop detach"`
+	Schema                       string        `mapstructure:"schema" validate:"required"`
+	Table                        string        `mapstructure:"table" validate:"required"`
+	PartitionKey                 string        `mapstructure:"partitionKey" validate:"required"`
+	Interval                     Interval      `mapstructure:"interval" validate:"required,oneof=daily weekly monthly quarterly yearly"`
+	Retention                    int           `mapstructure:"retention" validate:"required,gt=0"`
+	PreProvisioned               int           `mapstructure:"preProvisioned" validate:"required,gt=0"`
+	CleanupPolicy                CleanupPolicy `mapstructure:"cleanupPolicy" validate:"required,oneof=drop detach"`
+	ProvisionRetentionPartitions bool          `mapstructure:"provisionRetentionPartitions"`
 }
 
 func (p Configuration) GeneratePartition(forDate time.Time) (Partition, error) {

--- a/pkg/ppm/cleanup_test.go
+++ b/pkg/ppm/cleanup_test.go
@@ -12,13 +12,14 @@ import (
 )
 
 var OneDayPartitionConfiguration = partition.Configuration{
-	Schema:         "public",
-	Table:          "my_table",
-	PartitionKey:   "created_at",
-	Interval:       "daily",
-	Retention:      1,
-	PreProvisioned: 1,
-	CleanupPolicy:  "drop",
+	Schema:                       "public",
+	Table:                        "my_table",
+	PartitionKey:                 "created_at",
+	Interval:                     "daily",
+	Retention:                    1,
+	PreProvisioned:               1,
+	CleanupPolicy:                "drop",
+	ProvisionRetentionPartitions: true,
 }
 
 var ErrFake = errors.New("fake error")

--- a/pkg/ppm/provisioning.go
+++ b/pkg/ppm/provisioning.go
@@ -43,6 +43,11 @@ func (p PPM) provisionPartitionsFor(config partition.Configuration, at time.Time
 	}
 
 	for _, partition := range partitions {
+		isRetentionPartition := partition.UpperBound.Before(time.Now())
+		if isRetentionPartition && !config.ProvisionRetentionPartitions {
+			continue
+		}
+
 		if err := p.CreatePartition(config, partition); err != nil {
 			provisioningFailed = true
 

--- a/pkg/ppm/provisioning_test.go
+++ b/pkg/ppm/provisioning_test.go
@@ -21,6 +21,9 @@ func TestProvisioning(t *testing.T) {
 	TwoDayPartitionConfiguration.Retention = 2
 	TwoDayPartitionConfiguration.PreProvisioned = 2
 
+	ConfigurationWithoutProvisioningRetention := OneDayPartitionConfiguration
+	ConfigurationWithoutProvisioningRetention.ProvisionRetentionPartitions = false
+
 	testCases := []struct {
 		name                      string
 		partitions                map[string]partition.Configuration
@@ -33,6 +36,16 @@ func TestProvisioning(t *testing.T) {
 			},
 			[]partition.Partition{
 				yesterdayPartition,
+				currentPartition,
+				tomorrowPartition,
+			},
+		},
+		{
+			"Provisioning create preProvisioned without retention partitions",
+			map[string]partition.Configuration{
+				"unittest": ConfigurationWithoutProvisioningRetention,
+			},
+			[]partition.Partition{
 				currentPartition,
 				tomorrowPartition,
 			},


### PR DESCRIPTION
When provisioning partitions for the first time, the manager automatically creates a number of partitions in the past equal to the retention value. This can lead to the creation of a high number of useless partitions at the beginning of a project.

We propose to disable this behavior by default and enable it on demand using a new configuration property: `ProvisionRetentionPartitions` (boolean)

Fixes #38