### PR TITLE
Copy all properties of partitioned table when creating partition

### DIFF
--- a/internal/infra/postgresql/table.go
+++ b/internal/infra/postgresql/table.go
@@ -3,7 +3,7 @@ package postgresql
 import "fmt"
 
 func (p Postgres) CreateTableLikeTable(schema, table, parent string) error {
-	query := fmt.Sprintf("CREATE TABLE %s.%s (LIKE %s.%s)", schema, table, schema, parent)
+	query := fmt.Sprintf("CREATE TABLE %s.%s (LIKE %s.%s INCLUDING ALL)", schema, table, schema, parent)
 	p.logger.Debug("Create table", "query", schema, "table", table, "query", query)
 
 	_, err := p.conn.Exec(p.ctx, query)

--- a/internal/infra/postgresql/table_test.go
+++ b/internal/infra/postgresql/table_test.go
@@ -14,7 +14,7 @@ func TestCreateTableLikeTable(t *testing.T) {
 	table := "my_table"
 	parentTable := "parent_table"
 
-	query := fmt.Sprintf(`CREATE TABLE %s.%s (LIKE %s.%s)`, schema, table, schema, parentTable)
+	query := fmt.Sprintf(`CREATE TABLE %s.%s (LIKE %s.%s INCLUDING ALL)`, schema, table, schema, parentTable)
 
 	mock, p := setupMock(t, pgxmock.QueryMatcherEqual)
 


### PR DESCRIPTION
Partitions are currently created by using the following statement:
```
CREATE TABLE $schema.$table (LIKE $schema.$parent)
```

The LIKE clause specifies a table from which the new table automatically copies all column names, their data types, and their not-null constraints. By default, it excludes comments, compression, constraints, default values, generated expressions and indexes.

We want to include all these properties in order to generate partitions that completely mirror their partitioned table.

Fixes #39