### PR TITLE
Introduce manually managed partitions

### DIFF
--- a/internal/infra/partition/configuration.go
+++ b/internal/infra/partition/configuration.go
@@ -15,13 +15,14 @@ const (
 )
 
 type Configuration struct {
-	Schema         string        `mapstructure:"schema" validate:"required"`
-	Table          string        `mapstructure:"table" validate:"required"`
-	PartitionKey   string        `mapstructure:"partitionKey" validate:"required"`
-	Interval       Interval      `mapstructure:"interval" validate:"required,oneof=daily weekly monthly quarterly yearly"`
-	Retention      int           `mapstructure:"retention" validate:"required,gt=0"`
-	PreProvisioned int           `mapstructure:"preProvisioned" validate:"required,gt=0"`
-	CleanupPolicy  CleanupPolicy `mapstructure:"cleanupPolicy" validate:"required,oneof=drop detach"`
+	Schema                    string        `mapstructure:"schema" validate:"required"`
+	Table                     string        `mapstructure:"table" validate:"required"`
+	PartitionKey              string        `mapstructure:"partitionKey" validate:"required"`
+	Interval                  Interval      `mapstructure:"interval" validate:"required,oneof=daily weekly monthly quarterly yearly"`
+	Retention                 int           `mapstructure:"retention" validate:"required,gt=0"`
+	PreProvisioned            int           `mapstructure:"preProvisioned" validate:"required,gt=0"`
+	CleanupPolicy             CleanupPolicy `mapstructure:"cleanupPolicy" validate:"required,oneof=drop detach"`
+	ManuallyManagedPartitions []string      `mapstructure:"manuallyManagedPartitions"`
 }
 
 func (p Configuration) GeneratePartition(forDate time.Time) (Partition, error) {

--- a/pkg/ppm/cleanup.go
+++ b/pkg/ppm/cleanup.go
@@ -28,7 +28,7 @@ func (p PPM) CleanupPartitions() error {
 			return fmt.Errorf("could not list partitions: %w", err)
 		}
 
-		unexpected, _, _ := p.comparePartitions(foundPartitions, expectedPartitions)
+		unexpected, _, _ := p.comparePartitions(foundPartitions, expectedPartitions, config.ManuallyManagedPartitions)
 
 		for _, partition := range unexpected {
 			err := p.DetachPartition(partition)

--- a/pkg/ppm/export_test.go
+++ b/pkg/ppm/export_test.go
@@ -1,0 +1,10 @@
+package ppm
+
+import "github.com/qonto/postgresql-partition-manager/internal/infra/partition"
+
+func ComparePartitions(p *PPM,
+	existingTables, expectedTables []partition.Partition,
+	manuallyManagedPartitionNames []string,
+) (unexpectedTables, missingTables, incorrectBounds []partition.Partition) {
+	return p.comparePartitions(existingTables, expectedTables, manuallyManagedPartitionNames)
+}


### PR DESCRIPTION
The data used as a partition key is not always of the greatest quality. For instance, a timestamp column could contain some invalid dates referring to year -1. Ideally these values should be cleaned, but it is not always an option in a system where data is treated as immutable.

One way to deal with this situation is to add a default partition that will be in charge of containing data that cannot be assigned to any of the partitions already defined. Another solution, when the range of invalid values is known, is to move this data inside one or several dedicated partitions.

Both solutions involve the creation of partitions that cannot be managed by the partition manager, because their range break the policy defined for the other partitions.

For this reason we propose to introduce a new configuration property: `manuallyManagedPartitions`. It indicates which partitions should be ignored by the partition manager when checking or cleaning up partitions tables.