### PR TITLE
Improve bats tests

### DIFF
--- a/scripts/bats/20_check.bats
+++ b/scripts/bats/20_check.bats
@@ -5,7 +5,11 @@ load 'test/libs/seeds'
 load 'test/libs/sql'
 
 setup_file() {
-  reset_database
+  init_database
+}
+
+teardown_file() {
+  drop_database
 }
 
 setup() {

--- a/scripts/bats/20_check.bats
+++ b/scripts/bats/20_check.bats
@@ -49,6 +49,7 @@ EOF
 
   assert_success
   assert_output --partial "All partitions are correctly configured"
+  rm "$CONFIGURATION_FILE"
 }
 
 @test "Test check return an error when retention partitions are missing" {
@@ -79,6 +80,7 @@ EOF
 
   assert_failure
   assert_output --partial "Found missing tables"
+  rm "$CONFIGURATION_FILE"
 }
 
 @test "Test check return an error when preProvisioned partitions are missing" {
@@ -109,6 +111,7 @@ EOF
 
   assert_failure
   assert_output --partial "Found missing tables"
+  rm "$CONFIGURATION_FILE"
 }
 
 @test "Test check succeeding with an UUID partition key" {

--- a/scripts/bats/30_provisioning.bats
+++ b/scripts/bats/30_provisioning.bats
@@ -45,6 +45,8 @@ EOF
   assert_table_exists public $(generate_daily_partition_name ${TABLE} -1) # retention partition
   assert_table_exists public $(generate_daily_partition_name ${TABLE} 0) # current partition
   assert_table_exists public $(generate_daily_partition_name ${TABLE} 1) # preProvisioned partition
+
+  rm "$CONFIGURATION_FILE"
 }
 
 @test "Test that preProvisioned and retention partitions can be increased" {
@@ -90,6 +92,8 @@ EOF
   assert_output --partial "All partitions are correctly provisioned"
   assert_table_exists public $(generate_daily_partition_name ${TABLE} -${NEW_RETENTION}) # New retention partition
   assert_table_exists public $(generate_daily_partition_name ${TABLE} ${NEW_PREPROVISIONED}) # New preProvisioned partition
+
+  rm "$CONFIGURATION_FILE"
 }
 
 @test "Test monthly partitions" {
@@ -127,6 +131,8 @@ EOF
   assert_table_exists public ${EXPECTED_LAST_TABLE}
   assert_table_exists public ${EXPECTED_CURRENT_TABLE}
   assert_table_exists public ${EXPECTED_NEXT_TABLE}
+
+  rm "$CONFIGURATION_FILE"
 }
 
 @test "Test quarterly partitions" {
@@ -157,12 +163,13 @@ EOF
 
   run "$PPM_PROG" run provisioning -c ${CONFIGURATION_FILE}
 
-
   assert_success
   assert_output --partial "All partitions are correctly provisioned"
   assert_table_exists public ${EXPECTED_LAST_TABLE}
   assert_table_exists public ${EXPECTED_CURRENT_TABLE}
   assert_table_exists public ${EXPECTED_NEXT_TABLE}
+
+  rm "$CONFIGURATION_FILE"
 }
 
 @test "Test yearly partitions" {
@@ -198,6 +205,8 @@ EOF
   assert_table_exists public ${EXPECTED_LAST_TABLE}
   assert_table_exists public ${EXPECTED_CURRENT_TABLE}
   assert_table_exists public ${EXPECTED_NEXT_TABLE}
+
+  rm "$CONFIGURATION_FILE"
 }
 
 @test "Test interval change" {
@@ -264,6 +273,7 @@ EOF
   run list_existing_partitions "unittest" "public" ${TABLE}
   assert_output "$expected_mix"
 
+  rm "$CONFIGURATION_FILE"
 }
 
 @test "Test provisioning with multiple partition sets in the configuration" {
@@ -315,6 +325,8 @@ EOF
 
   run list_existing_partitions "unittest" "public" "table_unittest2"
   assert_output "$expected2"
+
+  rm "$CONFIGURATION_FILE"
 }
 
 @test "Test that provisioning continues after an error on a partition set" {
@@ -363,6 +375,8 @@ EOF
 
   run list_existing_partitions "unittest" "public" "${TABLE}"
   assert_output "$expected2"
+
+  rm "$CONFIGURATION_FILE"
 }
 
 @test "Test a timestamptz key with provisioning crossing a DST transition " {
@@ -414,5 +428,7 @@ EOF
 )
   run list_existing_partitions "unittest" "public" ${TABLE}
   assert_output "$expected_2"
+
+  rm "$CONFIGURATION_FILE"
 
 }

--- a/scripts/bats/30_provisioning.bats
+++ b/scripts/bats/30_provisioning.bats
@@ -6,7 +6,11 @@ load 'test/libs/sql'
 load 'test/libs/time'
 
 setup_file() {
-  reset_database
+  init_database
+}
+
+teardown_file() {
+  drop_database
 }
 
 setup() {
@@ -237,7 +241,7 @@ EOF
   assert_success
   assert_output --partial "All partitions are correctly provisioned"
 
-  run list_existing_partitions "unittest" "public" ${TABLE}
+  run list_existing_partitions "public" ${TABLE}
 
   local expected_monthly=$(cat <<EOF
 public|test_interv_2024_12|2024-12-01|2025-01-01
@@ -270,7 +274,7 @@ public|test_interv_2025_w15|2025-04-07|2025-04-14
 EOF
   )
 
-  run list_existing_partitions "unittest" "public" ${TABLE}
+  run list_existing_partitions "public" ${TABLE}
   assert_output "$expected_mix"
 
   rm "$CONFIGURATION_FILE"
@@ -311,7 +315,7 @@ public|table_unittest1_2025_02_01|2025-02-01|2025-02-02
 public|table_unittest1_2025_02_02|2025-02-02|2025-02-03
 EOF
   )
-  run list_existing_partitions "unittest" "public" "table_unittest1"
+  run list_existing_partitions "public" "table_unittest1"
   assert_output "$expected1"
 
   local expected2=$(cat <<'EOF'
@@ -323,7 +327,7 @@ public|table_unittest2_2025_02_03|2025-02-03|2025-02-04
 EOF
   )
 
-  run list_existing_partitions "unittest" "public" "table_unittest2"
+  run list_existing_partitions "public" "table_unittest2"
   assert_output "$expected2"
 
   rm "$CONFIGURATION_FILE"
@@ -373,7 +377,7 @@ public|${TABLE}_2025_02_03|2025-02-03|2025-02-04
 EOF
   )
 
-  run list_existing_partitions "unittest" "public" "${TABLE}"
+  run list_existing_partitions "public" "${TABLE}"
   assert_output "$expected2"
 
   rm "$CONFIGURATION_FILE"
@@ -406,7 +410,7 @@ public|${TABLE}_2025_w12|2025-03-17 00:00:00+01|2025-03-24 00:00:00+01
 EOF
   )
 
-  run list_existing_partitions "unittest" "public" ${TABLE}
+  run list_existing_partitions "public" ${TABLE}
   assert_output "$expected_1"
 
   # Now advance one week up to the end of March 2025
@@ -426,7 +430,7 @@ public|${TABLE}_2025_w12|2025-03-17 00:00:00+01|2025-03-24 00:00:00+01
 public|${TABLE}_2025_w13|2025-03-24 00:00:00+01|2025-03-31 00:00:00+02
 EOF
 )
-  run list_existing_partitions "unittest" "public" ${TABLE}
+  run list_existing_partitions "public" ${TABLE}
   assert_output "$expected_2"
 
   rm "$CONFIGURATION_FILE"

--- a/scripts/bats/40_cleanup.bats
+++ b/scripts/bats/40_cleanup.bats
@@ -63,6 +63,8 @@ EOF
   for ((i=NEW_RETENTION +1; i<= INITIAL_PREPROVISIONED; i++));do
     assert_table_not_exists public $(generate_daily_partition_name ${TABLE} ${i})
   done
+
+  rm "$CONFIGURATION_FILE"
 }
 
 @test "Test that gaps in the partition set prevent any partition removal" {

--- a/scripts/bats/40_cleanup.bats
+++ b/scripts/bats/40_cleanup.bats
@@ -5,7 +5,11 @@ load 'test/libs/seeds'
 load 'test/libs/sql'
 
 setup_file() {
-  reset_database
+  init_database
+}
+
+teardown_file() {
+  drop_database
 }
 
 setup() {
@@ -119,7 +123,7 @@ EOF
     expected+="public|${PARTS[i]}|${PARTS[i+1]}|${PARTS[i+2]}"
     (( i+=3 ))
   done
-  run list_existing_partitions "unittest" "public" "${TABLE}"
+  run list_existing_partitions "public" "${TABLE}"
 
   assert_output "$expected"
 

--- a/scripts/bats/configuration/template.yaml
+++ b/scripts/bats/configuration/template.yaml
@@ -3,4 +3,4 @@ debug: true
 
 log-format: text
 
-connection-url: postgres://postgres:hackme@localhost/unittest
+#connection-url: postgres://user:password@localhost/dbname

--- a/scripts/bats/test/libs/partitions.bash
+++ b/scripts/bats/test/libs/partitions.bash
@@ -52,7 +52,7 @@ generate_daily_partition_name() {
 }
 
 generate_table_name() {
-  cat /dev/urandom | head -n 1 | base64 | tr -dc '[:alnum:]' | tr '[:upper:]' '[:lower:]' | cut -c -13 | sed -e 's/^[0-9]/a/g'
+  echo "tbl_"$(random_suffix)
 }
 
 # Generic method to create child partitions with specified ranges

--- a/scripts/bats/test/libs/partitions.bash
+++ b/scripts/bats/test/libs/partitions.bash
@@ -41,7 +41,7 @@ generate_daily_partition() {
   local UPPER_BOUND=$(date -d "@$(( $(date +%s) + 86400 * $TIMEDELTA + 86400))" +"%Y-%m-%d")
 
   local QUERY="CREATE TABLE ${TABLE_NAME} PARTITION OF ${PARENT_TABLE} FOR VALUES FROM ('${LOWER_BOUND}') TO ('${UPPER_BOUND}');"
-  execute_sql "${QUERY}"
+  execute_sql "${QUERY}" "$PPM_DATABASE"
 }
 
 generate_daily_partition_name() {
@@ -85,5 +85,5 @@ create_partitions() {
     done
     sql_block="$sql_block
 		COMMIT;";
-    execute_sql_commands "$sql_block"
+    execute_sql_commands "$sql_block" "$PPM_DATABASE"
 }

--- a/scripts/bats/test/libs/seeds.bash
+++ b/scripts/bats/test/libs/seeds.bash
@@ -1,3 +1,9 @@
+# Emit a random string suitable for unquoted database identifiers (lower case, ASCII)
+# The result may start with a number.
+random_suffix() {
+  head -c 12 /dev/urandom | base64 | tr -dc '[:alnum:]' | tr '[:upper:]' '[:lower:]'
+}
+
 init_database() {
   QUERY="CREATE DATABASE unittest;"
   execute_sql "${QUERY}" postgres

--- a/scripts/bats/test/libs/seeds.bash
+++ b/scripts/bats/test/libs/seeds.bash
@@ -67,8 +67,8 @@ generate_configuration_file() {
 
   local FILENAME=$(mktemp).yaml
   yq '. as $item ireduce ({}; . * $item )' "${CONFIGURATION_TEMPLATE_FILE}" "${TEMPORARY_FILE}" > "${FILENAME}"
-
-  echo $FILENAME
+  rm "${TEMPORARY_FILE}"
+  echo "$FILENAME"
 }
 
 # Return a common configuration

--- a/scripts/bats/test/libs/seeds.bash
+++ b/scripts/bats/test/libs/seeds.bash
@@ -5,13 +5,17 @@ random_suffix() {
 }
 
 init_database() {
-  QUERY="CREATE DATABASE unittest;"
+  local dbname="ppm_test_"$(random_suffix)
+  QUERY="CREATE DATABASE \"$dbname\" ;"
   execute_sql "${QUERY}" postgres
+  export PPM_DATABASE="$dbname"
+  export PGDATABASE="$dbname"
 }
 
 drop_database() {
-  QUERY="set lock_timeout to '5s'; DROP DATABASE IF EXISTS unittest;"
+  QUERY="set lock_timeout to '5s'; DROP DATABASE IF EXISTS \"$PPM_DATABASE\" ;"
   execute_sql_commands "${QUERY}" postgres
+  unset PPM_DATABASE
 }
 
 reset_database() {
@@ -29,7 +33,7 @@ create_table_from_template() {
     created_at      DATE NOT NULL
   ) PARTITION BY RANGE (created_at);
 EOQ
-  execute_sql "${QUERY}"
+  execute_sql "${QUERY}" "${PPM_DATABASE}"
 }
 
 create_table_uuid_range() {


### PR DESCRIPTION
- don't use the hardcoded "unittest" db name (dangerous in local tests)
- fix generation of random table names
- clean up the dozen of yaml files left by each run