### PR TITLE
fix: use proper quoting for table names

### DIFF
--- a/internal/infra/postgresql/table.go
+++ b/internal/infra/postgresql/table.go
@@ -1,9 +1,15 @@
 package postgresql
 
-import "fmt"
+import (
+	"fmt"
+
+	"github.com/jackc/pgx/v5"
+)
 
 func (p Postgres) CreateTableLikeTable(schema, table, parent string) error {
-	query := fmt.Sprintf("CREATE TABLE %s.%s (LIKE %s.%s INCLUDING ALL)", schema, table, schema, parent)
+	query := fmt.Sprintf("CREATE TABLE %s (LIKE %s INCLUDING ALL)",
+		pgx.Identifier{schema, table}.Sanitize(),
+		pgx.Identifier{schema, parent}.Sanitize())
 	p.logger.Debug("Create table", "schema", schema, "table", table, "query", query)
 
 	_, err := p.conn.Exec(p.ctx, query)

--- a/internal/infra/postgresql/table_test.go
+++ b/internal/infra/postgresql/table_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/jackc/pgx/v5"
 	"github.com/pashagolub/pgxmock/v3"
 	"github.com/stretchr/testify/assert"
 )
@@ -14,7 +15,9 @@ func TestCreateTableLikeTable(t *testing.T) {
 	table := "my_table"
 	parentTable := "parent_table"
 
-	query := fmt.Sprintf(`CREATE TABLE %s.%s (LIKE %s.%s INCLUDING ALL)`, schema, table, schema, parentTable)
+	query := fmt.Sprintf("CREATE TABLE %s (LIKE %s INCLUDING ALL)",
+		pgx.Identifier{schema, table}.Sanitize(),
+		pgx.Identifier{schema, parentTable}.Sanitize())
 
 	mock, p := setupMock(t, pgxmock.QueryMatcherEqual)
 

--- a/scripts/bats/test/libs/sql.bash
+++ b/scripts/bats/test/libs/sql.bash
@@ -38,14 +38,14 @@ EOSQL
 
 list_existing_partitions() {
   # mandatory arguments
-  local PARENT_SCHEMA=$1
-  local PARENT_TABLE=$2
+  local PARENT_SCHEMA="$1"
+  local PARENT_TABLE="$2"
 
-  psql --tuples-only --no-align --quiet --dbname="$PPM_DATABASE" -v parent_schema=${PARENT_SCHEMA} -v parent_table=${PARENT_TABLE} <<'EOSQL'
+  psql --tuples-only --no-align --quiet --dbname="$PPM_DATABASE" -v parent_schema="${PARENT_SCHEMA}" -v parent_table="${PARENT_TABLE}" <<'EOSQL'
 WITH parts as (
 	SELECT
 	   relnamespace::regnamespace as schema,
-	   c.oid::pg_catalog.regclass AS part_name,
+	   c.relname AS part_name,
 	   regexp_match(pg_get_expr(c.relpartbound, c.oid),
 				  'FOR VALUES FROM \(''(.*)''\) TO \(''(.*)''\)') AS bounds
 	 FROM


### PR DESCRIPTION
When table names contain special characters that require identifiers to be quoted, the code was not quoting properly.

In particular:

- calling Sprintf("%s.%s") with unquoted table and schema names is not safe to build SQL statements. pgx.Identifier.Sanitize() is used instead.

- Casting to regclass to convert OID to names is too complicated because it can produce quoted or unquoted names depending on the context. Use pg_class and pg_namespace instead.

- Casting to regclass to convert names to OID depends on the search_path, and also requires pre-quoting, which makes it difficult to use properly with user-supplied arguments. Use pg_class and pg_namespace instead.