### PR TITLE
Update Golang to 1.26

### DIFF
--- a/.github/workflows/linter.yaml
+++ b/.github/workflows/linter.yaml
@@ -16,7 +16,7 @@ jobs:
       - uses: actions/checkout@v5
       - uses: actions/setup-go@v5
         with:
-          go-version: '1.23'
+          go-version: '1.26'
           cache: false
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v9

--- a/.github/workflows/linter.yaml
+++ b/.github/workflows/linter.yaml
@@ -14,14 +14,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@v6
         with:
           go-version: '1.26'
           cache: false
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v9
         with:
-          version: v1.61
+          version: v2.11.4
 
   yamllint:
     name: yamllint

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -34,7 +34,7 @@ jobs:
 
       - run: git fetch --force --tags
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@v6
         with:
           go-version: stable
 

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -19,7 +19,7 @@ jobs:
       - uses: actions/checkout@v5
       - uses: actions/setup-go@v5
         with:
-          go-version: '1.23'
+          go-version: '1.26'
       - name: Install dependencies
         run: |
           go get .
@@ -169,7 +169,7 @@ jobs:
       - uses: actions/checkout@v5
       - uses: actions/setup-go@v5
         with:
-          go-version: '1.23'
+          go-version: '1.26'
       - name: Install dependencies
         run: |
           go get .

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -17,7 +17,7 @@ jobs:
       pull-requests: write
     steps:
       - uses: actions/checkout@v5
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@v6
         with:
           go-version: '1.26'
       - name: Install dependencies
@@ -124,7 +124,7 @@ jobs:
         uses: actions/checkout@v5
         with:
           fetch-depth: 0
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@v6
         with:
           go-version: stable
       - name: Set up QEMU for ARM64 build
@@ -167,7 +167,7 @@ jobs:
           - 5432:5432
     steps:
       - uses: actions/checkout@v5
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@v6
         with:
           go-version: '1.26'
       - name: Install dependencies

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -68,17 +68,6 @@ linters:
     lll:
       line-length: 120
 
-  exclusions:
-    warn-unused: true
-    rules:
-      # Exclude some linters from running on test files
-      - path: _test\.go
-        linters:
-          # bodyclose reports some false-positives when using a test request recorder
-          - bodyclose
-          # It's overkill to use `NewRequestWithContext` in tests
-          - noctx
-
 formatters:
   enable:
     - gofmt

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -54,7 +54,7 @@ linters:
     - wastedassign
     - whitespace
     - wrapcheck
-    - wsl
+    - wsl_v5
 
   settings:
     gocyclo:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,26 +1,19 @@
 ---
+version: "2"
+
 run:
   concurrency: 4
   timeout: 2m
   issues-exit-code: 1
   tests: true
 
-output:
-  formats:
-    - format: colored-line-number
-  print-issued-lines: true
-  print-linter-name: true
-
 linters:
-  enable-all: false
-  disable-all: false
+  default: none
   enable:
     - errcheck
-    - gosimple
     - govet
     - ineffassign
     - staticcheck
-    - typecheck
     - unused
     - asciicheck
     - bodyclose
@@ -35,9 +28,6 @@ linters:
     - gocyclo
     - godox
     - err113
-    - gofmt
-    - gofumpt
-    - goimports
     - mnd
     - gomodguard
     - goprintffuncname
@@ -56,7 +46,7 @@ linters:
     - revive
     - rowserrcheck
     - sqlclosecheck
-    - stylecheck
+    #- stylecheck
     - testpackage
     - thelper
     - tparallel
@@ -67,28 +57,31 @@ linters:
     - wrapcheck
     - wsl
 
-linters-settings:
-  gocyclo:
-    min-complexity: 35
+  settings:
+    gocyclo:
+      min-complexity: 35
 
-  revive:
+    revive:
+      rules:
+        - name: exported
+          disabled: true
+
+    lll:
+      line-length: 120
+
+  exclusions:
+    warn-unused: true
     rules:
-      - name: exported
-        disabled: true
+      # Exclude some linters from running on test files
+      - path: _test\.go
+        linters:
+          # bodyclose reports some false-positives when using a test request recorder
+          - bodyclose
+          # It's overkill to use `NewRequestWithContext` in tests
+          - noctx
 
-  lll:
-    line-length: 120
-
-issues:
-  exclude-use-default: false
-  max-issues-per-linter: 1024
-  max-same-issues: 1024
-
-  exclude-rules:
-    # Exclude some linters from running on test files
-    - path: _test\.go
-      linters:
-        # bodyclose reports some false-positives when using a test request recorder
-        - bodyclose
-        # It's overkill to use `NewRequestWithContext` in tests
-        - noctx
+formatters:
+  enable:
+    - gofmt
+    - gofumpt
+    - goimports

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -46,7 +46,6 @@ linters:
     - revive
     - rowserrcheck
     - sqlclosecheck
-    #- stylecheck
     - testpackage
     - thelper
     - tparallel

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.22 AS builder
+FROM golang:1.26 AS builder
 
 WORKDIR /build
 

--- a/Makefile
+++ b/Makefile
@@ -84,6 +84,8 @@ test:
 
 .PHONY: lint
 lint:
+	golangci-lint config verify
+	golangci-lint cache clean
 	golangci-lint run --verbose --timeout 2m
 
 .PHONY: all-tests

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,6 @@
 module github.com/qonto/postgresql-partition-manager
 
-go 1.23.0
-
-toolchain go1.23.2
+go 1.26.0
 
 require (
 	github.com/go-playground/validator/v10 v10.22.0

--- a/internal/infra/partition/bounds.go
+++ b/internal/infra/partition/bounds.go
@@ -58,7 +58,7 @@ func (r PartitionRange) IsEqual(r2 PartitionRange) bool {
 func (r PartitionRange) Intersection(r2 PartitionRange) PartitionRange {
 	var res PartitionRange // initialized with {time.Time{}, time.Time{}}
 
-	if !(r2.LowerBound.After(r.UpperBound) || r.LowerBound.After(r2.UpperBound)) { // !empty intersection
+	if !r2.LowerBound.After(r.UpperBound) && !r.LowerBound.After(r2.UpperBound) { // !empty intersection
 		if r.LowerBound.After(r2.LowerBound) {
 			res.LowerBound = r.LowerBound
 		} else {

--- a/internal/infra/partition/configuration.go
+++ b/internal/infra/partition/configuration.go
@@ -128,7 +128,8 @@ func (p Configuration) getPrevDate(forDate time.Time, i int) (t time.Time, err e
 		t = time.Date(year, month-time.Month(i), 1, 0, 0, 0, 0, forDate.Location())
 	case Quarterly:
 		year, month, _ := forDate.Date()
-		quarterStartMonth := (month-1)/3*3 + 1
+		quarter := (int(month) - 1) / nbMonthsInAQuarter
+		quarterStartMonth := time.Month(quarter*nbMonthsInAQuarter + 1)
 		t = time.Date(year, quarterStartMonth-time.Month(i*nbMonthsInAQuarter), 1, 0, 0, 0, 0, forDate.Location())
 	case Yearly:
 		year, _, _ := forDate.Date()
@@ -153,7 +154,8 @@ func (p Configuration) getNextDate(forDate time.Time, i int) (t time.Time, err e
 		t = time.Date(year, month+time.Month(i), 1, 0, 0, 0, 0, forDate.Location())
 	case Quarterly:
 		year, month, _ := forDate.Date()
-		quarterStartMonth := (month-1)/3*3 + 1
+		quarter := (int(month) - 1) / nbMonthsInAQuarter
+		quarterStartMonth := time.Month(quarter*nbMonthsInAQuarter + 1)
 		t = time.Date(year, quarterStartMonth+time.Month(i*nbMonthsInAQuarter), 1, 0, 0, 0, 0, forDate.Location())
 	case Yearly:
 		year, _, _ := forDate.Date()

--- a/internal/infra/postgresql/partition.go
+++ b/internal/infra/postgresql/partition.go
@@ -168,7 +168,8 @@ func (p Postgres) SetPartitionReplicaIdentity(schema, table, parent string) erro
 		return fmt.Errorf("failed to check pg_class.relreplident for parent table: %w", err)
 	}
 
-	if replIdent == "f" { // replica identity = full
+	switch replIdent {
+	case "f": // replica identity = full
 		queryFull := fmt.Sprintf("ALTER TABLE %s REPLICA IDENTITY FULL",
 			pgx.Identifier{schema, table}.Sanitize())
 		p.logger.Debug("Set identity full", "query", queryFull)
@@ -177,7 +178,7 @@ func (p Postgres) SetPartitionReplicaIdentity(schema, table, parent string) erro
 		if err != nil {
 			return fmt.Errorf("failed to set replica identity: %w", err)
 		}
-	} else if replIdent == "i" { // replica identity = specific index
+	case "i": // replica identity = specific index
 		var indexName string
 		/* This query finds the index that is a child of the (only) index
 		   in the parent table having "indisreplident"=true.

--- a/internal/infra/postgresql/partition_test.go
+++ b/internal/infra/postgresql/partition_test.go
@@ -1,4 +1,4 @@
-//nolint:golint,wsl_v5
+//nolint:wsl_v5
 package postgresql_test
 
 import (

--- a/internal/infra/postgresql/partition_test.go
+++ b/internal/infra/postgresql/partition_test.go
@@ -1,4 +1,4 @@
-//nolint:golint,wsl,goconst
+//nolint:golint,wsl_v5
 package postgresql_test
 
 import (

--- a/internal/infra/postgresql/postgresql_test.go
+++ b/internal/infra/postgresql/postgresql_test.go
@@ -22,7 +22,7 @@ func setupMock(t *testing.T, queryMatcher pgxmock.QueryMatcher) (pgxmock.PgxConn
 		t.Fatalf("ERROR: Fail to initialize PostgreSQL mock: %s", err)
 	}
 
-	defer mock.Close(context.TODO()) //nolint:golint,errcheck
+	defer mock.Close(context.TODO()) //nolint:errcheck
 
 	logger, err := logger.New(false, "text")
 	if err != nil {

--- a/internal/infra/postgresql/server_test.go
+++ b/internal/infra/postgresql/server_test.go
@@ -1,4 +1,4 @@
-//nolint:golint,wsl
+//nolint:golint,wsl_v5
 package postgresql_test
 
 import (

--- a/internal/infra/postgresql/server_test.go
+++ b/internal/infra/postgresql/server_test.go
@@ -1,4 +1,4 @@
-//nolint:golint,wsl_v5
+//nolint:wsl_v5
 package postgresql_test
 
 import (

--- a/internal/infra/postgresql/table_test.go
+++ b/internal/infra/postgresql/table_test.go
@@ -1,4 +1,4 @@
-//nolint:golint,wsl
+//nolint:golint,wsl_v5
 package postgresql_test
 
 import (

--- a/internal/infra/postgresql/table_test.go
+++ b/internal/infra/postgresql/table_test.go
@@ -1,4 +1,4 @@
-//nolint:golint,wsl_v5
+//nolint:wsl_v5
 package postgresql_test
 
 import (

--- a/internal/infra/postgresql/table_test.go
+++ b/internal/infra/postgresql/table_test.go
@@ -10,10 +10,16 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+const (
+	testSchema      = "public"
+	testTable       = "my_table"
+	testParentTable = "parent_table"
+)
+
 func TestCreateTableLikeTable(t *testing.T) {
-	schema := "public"
-	table := "my_table"
-	parentTable := "parent_table"
+	schema := testSchema
+	table := testTable
+	parentTable := testParentTable
 
 	query := fmt.Sprintf("CREATE TABLE %s (LIKE %s INCLUDING ALL)",
 		pgx.Identifier{schema, table}.Sanitize(),
@@ -31,8 +37,8 @@ func TestCreateTableLikeTable(t *testing.T) {
 }
 
 func TestDropTable(t *testing.T) {
-	schema := "public"
-	table := "my_table"
+	schema := testSchema
+	table := testTable
 	fullQualifiedName := fmt.Sprintf("%s.%s", schema, table)
 	query := fmt.Sprintf(`DROP TABLE %s`, fullQualifiedName)
 
@@ -48,8 +54,8 @@ func TestDropTable(t *testing.T) {
 }
 
 func TestIsTableExists(t *testing.T) {
-	schema := "public"
-	table := "my_table"
+	schema := testSchema
+	table := testTable
 
 	query := "SELECT EXISTS"
 

--- a/internal/infra/retry/retry_test.go
+++ b/internal/infra/retry/retry_test.go
@@ -41,7 +41,6 @@ func TestWithRetry(t *testing.T) {
 		}
 
 		err := retry.WithRetry(maxRetries, operation)
-
 		if err == nil {
 			t.Fatalf("expected error, but got none")
 		}

--- a/internal/infra/uuid7/uuid7.go
+++ b/internal/infra/uuid7/uuid7.go
@@ -27,7 +27,7 @@ func FromTime(timestamp time.Time) string {
 
 	// Bytes 0-5: 48-bit unix_ts_ms (big-endian)
 	ts := make([]byte, 8)
-	binary.BigEndian.PutUint64(ts, uint64(unixMillis)) //nolint:gosec
+	binary.BigEndian.PutUint64(ts, uint64(unixMillis))
 	copy(buf[0:6], ts[2:])
 
 	// Byte 6: upper nibble = version 0b0111, lower nibble = rand_a[0:3] (zero)

--- a/pkg/ppm/checkpartition_test.go
+++ b/pkg/ppm/checkpartition_test.go
@@ -38,7 +38,6 @@ func setupMocks(t *testing.T) (*slog.Logger, *mocks.PostgreSQLClient) {
 
 func TestCheckPartitions(t *testing.T) {
 	logger, postgreSQLMock := setupMocks(t)
-	boundDateFormat := "2006-01-02" //nolint:goconst
 
 	partitions := map[string]partition.Configuration{}
 	partitions["daily partition"] = partition.Configuration{Schema: "app", Table: "daily_table1", PartitionKey: "column", Interval: partition.Daily, Retention: 2, PreProvisioned: 2}
@@ -112,7 +111,6 @@ func TestCheckPartitions(t *testing.T) {
 
 func TestCheckMissingPartitions(t *testing.T) {
 	logger, postgreSQLMock := setupMocks(t)
-	boundDateFormat := "2006-01-02"
 
 	config := partition.Configuration{
 		Schema:         "public",

--- a/pkg/ppm/checkpartition_test.go
+++ b/pkg/ppm/checkpartition_test.go
@@ -52,7 +52,6 @@ func TestCheckPartitions(t *testing.T) {
 	// Build mock for each partitions
 	for _, p := range partitions {
 		var (
-			tables               []partition.Partition
 			retentionTables      []partition.Partition
 			preprovisionedTables []partition.Partition
 		)
@@ -75,11 +74,8 @@ func TestCheckPartitions(t *testing.T) {
 			t.Errorf("unuspported partition interval in retention table mock")
 		}
 
-		tables = append(tables, retentionTables...)
-
 		// Create current partition
 		currentPartition, _ := p.GeneratePartition(forDate)
-		tables = append(tables, currentPartition)
 
 		// Create preprovisioned partitions
 		switch p.Interval {
@@ -97,6 +93,9 @@ func TestCheckPartitions(t *testing.T) {
 			t.Errorf("unuspported partition interval in preprovisonned table mock")
 		}
 
+		tables := make([]partition.Partition, 0, len(retentionTables)+1+len(preprovisionedTables))
+		tables = append(tables, retentionTables...)
+		tables = append(tables, currentPartition)
 		tables = append(tables, preprovisionedTables...)
 
 		postgreSQLMock.On("GetColumnDataType", p.Schema, p.Table, p.PartitionKey).Return(postgresql.Date, nil).Once()

--- a/pkg/ppm/checkpartition_test.go
+++ b/pkg/ppm/checkpartition_test.go
@@ -101,7 +101,7 @@ func TestCheckPartitions(t *testing.T) {
 
 		postgreSQLMock.On("GetPartitionSettings", p.Schema, p.Table).Return(string(partition.Range), p.PartitionKey, nil).Once()
 
-		convertedTables := partitionResultToPartition(t, tables, boundDateFormat)
+		convertedTables := partitionResultToPartition(t, tables)
 		postgreSQLMock.On("ListPartitions", p.Schema, p.Table).Return(convertedTables, nil).Once()
 	}
 
@@ -158,7 +158,7 @@ func TestCheckMissingPartitions(t *testing.T) {
 			postgreSQLMock.On("GetPartitionSettings", config.Schema, config.Table).Return(string(partition.Range), config.PartitionKey, nil).Once()
 			postgreSQLMock.On("GetColumnDataType", config.Schema, config.Table, config.PartitionKey).Return(postgresql.Date, nil).Once()
 
-			tables := partitionResultToPartition(t, tc.tables, boundDateFormat)
+			tables := partitionResultToPartition(t, tc.tables)
 			postgreSQLMock.On("ListPartitions", config.Schema, config.Table).Return(tables, nil).Once()
 
 			checker := ppm.New(context.TODO(), *logger, postgreSQLMock, map[string]partition.Configuration{"test": config}, time.Now())

--- a/pkg/ppm/cleanup_test.go
+++ b/pkg/ppm/cleanup_test.go
@@ -74,7 +74,7 @@ func TestCleanupPartitions(t *testing.T) {
 			logger, postgreSQLMock := setupMocks(t) // Reset mock on every test case
 
 			for _, partitionConfiguration := range tc.partitions {
-				postgreSQLMock.On("ListPartitions", partitionConfiguration.Schema, partitionConfiguration.Table).Return(partitionResultToPartition(t, tc.existingPartitions, boundDateFormat), nil).Once()
+				postgreSQLMock.On("ListPartitions", partitionConfiguration.Schema, partitionConfiguration.Table).Return(partitionResultToPartition(t, tc.existingPartitions), nil).Once()
 
 				for _, p := range tc.expectedRemovedPartitions {
 					postgreSQLMock.On("DetachPartitionConcurrently", p.Schema, p.Name, p.ParentTable).Return(nil).Once()
@@ -129,7 +129,7 @@ func TestCleanupPartitionsFailover(t *testing.T) {
 			tomorrowPartitionPartition,
 		}
 
-		postgreSQLMock.On("ListPartitions", config.Schema, config.Table).Return(partitionResultToPartition(t, partitions, boundDateFormat), nil).Once()
+		postgreSQLMock.On("ListPartitions", config.Schema, config.Table).Return(partitionResultToPartition(t, partitions), nil).Once()
 	}
 
 	// Undetachable partition will return an error on detach operation

--- a/pkg/ppm/cleanup_test.go
+++ b/pkg/ppm/cleanup_test.go
@@ -37,8 +37,6 @@ func TestCleanupPartitions(t *testing.T) {
 	dropPartitionConfiguration := OneDayPartitionConfiguration
 	OneDayPartitionConfiguration.CleanupPolicy = "drop"
 
-	boundDateFormat := "2006-01-02"
-
 	testCases := []struct {
 		name                      string
 		partitions                map[string]partition.Configuration
@@ -115,8 +113,6 @@ func TestCleanupPartitionsFailover(t *testing.T) {
 		"pendingFinalize": pendingFinalizePartitionConfiguration,
 		"success":         successPartitionConfiguration,
 	}
-
-	boundDateFormat := "2006-01-02"
 
 	logger, postgreSQLMock := setupMocks(t)
 

--- a/pkg/ppm/ppm_test.go
+++ b/pkg/ppm/ppm_test.go
@@ -9,7 +9,7 @@ import (
 
 const boundDateFormat = "2006-01-02"
 
-func partitionResultToPartition(t *testing.T, partitions []partition.Partition, dateFormat string) (result []postgresql.PartitionResult) {
+func partitionResultToPartition(t *testing.T, partitions []partition.Partition) (result []postgresql.PartitionResult) {
 	t.Helper()
 
 	for _, p := range partitions {
@@ -17,8 +17,8 @@ func partitionResultToPartition(t *testing.T, partitions []partition.Partition, 
 			ParentTable: p.ParentTable,
 			Schema:      p.Schema,
 			Name:        p.Name,
-			LowerBound:  p.LowerBound.Format(dateFormat),
-			UpperBound:  p.UpperBound.Format(dateFormat),
+			LowerBound:  p.LowerBound.Format(boundDateFormat),
+			UpperBound:  p.UpperBound.Format(boundDateFormat),
 		})
 	}
 

--- a/pkg/ppm/ppm_test.go
+++ b/pkg/ppm/ppm_test.go
@@ -7,6 +7,8 @@ import (
 	"github.com/qonto/postgresql-partition-manager/internal/infra/postgresql"
 )
 
+const boundDateFormat = "2006-01-02"
+
 func partitionResultToPartition(t *testing.T, partitions []partition.Partition, dateFormat string) (result []postgresql.PartitionResult) {
 	t.Helper()
 

--- a/scripts/localdev/configuration/bats/Dockerfile
+++ b/scripts/localdev/configuration/bats/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.23 AS builder
+FROM golang:1.26 AS builder
 ARG GOPROXY=direct
 
 WORKDIR /build


### PR DESCRIPTION
# Objective

Update Golang from 1.23 to 1.26

# Why

We are running outdated Golang version and dependabot PRs are requiring Golang version update

# How

- Bump Golang version in go.mod
- Bump Golang version in docker containers
- Bump Golang version in CI
- Bump Golanglinter
- Fix linter errors

# Release plan

Merge this PR and check CI tests