### PR TITLE
Use portable date formatting command in bats

### DIFF
--- a/scripts/bats/test/libs/partitions.bash
+++ b/scripts/bats/test/libs/partitions.bash
@@ -1,3 +1,19 @@
+# Portable date formatting from epoch timestamp
+# Usage: format_epoch EPOCH FORMAT
+# Works on both GNU/Linux (date -d) and macOS/BSD (date -r)
+format_epoch() {
+  local epoch=$1
+  local fmt=$2
+
+  if date -d "@0" +"%Y" >/dev/null 2>&1; then
+    # GNU date
+    date -d "@${epoch}" +"${fmt}"
+  else
+    # BSD/macOS date
+    date -r "${epoch}" +"${fmt}"
+  fi
+}
+
 create_partitioned_table() {
   create_table_from_template "$1"
 }
@@ -37,8 +53,8 @@ generate_daily_partition() {
   local TIMEDELTA=$2
 
   local TABLE_NAME=$(generate_daily_partition_name "${PARENT_TABLE}" "${TIMEDELTA}")
-  local LOWER_BOUND=$(date -d "@$(( $(date +%s) + 86400 * $TIMEDELTA))" +"%Y-%m-%d")
-  local UPPER_BOUND=$(date -d "@$(( $(date +%s) + 86400 * $TIMEDELTA + 86400))" +"%Y-%m-%d")
+  local LOWER_BOUND=$(format_epoch "$(( $(date +%s) + 86400 * $TIMEDELTA))" "%Y-%m-%d")
+  local UPPER_BOUND=$(format_epoch "$(( $(date +%s) + 86400 * $TIMEDELTA + 86400))" "%Y-%m-%d")
 
   local QUERY="CREATE TABLE ${TABLE_NAME} PARTITION OF ${PARENT_TABLE} FOR VALUES FROM ('${LOWER_BOUND}') TO ('${UPPER_BOUND}');"
   execute_sql "${QUERY}" "$PPM_DATABASE"
@@ -48,7 +64,7 @@ generate_daily_partition_name() {
   local PARENT_TABLE=$1
   local TIMEDELTA=$2
 
-  echo $(date -d "@$(( $(date +%s) + 86400 * $TIMEDELTA))" +"${PARENT_TABLE}_%Y_%m_%d")
+  echo $(format_epoch "$(( $(date +%s) + 86400 * $TIMEDELTA))" "${PARENT_TABLE}_%Y_%m_%d")
 }
 
 generate_table_name() {

--- a/scripts/localdev/docker-compose.yml
+++ b/scripts/localdev/docker-compose.yml
@@ -17,6 +17,11 @@ services:
       - ./.data/postgres:/var/lib/postgresql
       - ./configuration/postgres/seeds:/docker-entrypoint-initdb.d
     command: "postgres -c log_statement=all -c log_line_prefix='%t:%r:user=%u,database=%d,app=%a,query_id=%Q:[%p]:'"
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U postgres"]
+      interval: 2s
+      timeout: 5s
+      retries: 10
     tmpfs:
       - /var/run
 
@@ -24,6 +29,9 @@ services:
     build:
       context: ../../
       dockerfile: scripts/localdev/configuration/bats/Dockerfile
+    depends_on:
+      postgres:
+        condition: service_healthy
     environment:
       PGHOST: postgres
       PGUSER: postgres


### PR DESCRIPTION
# Goal

Allow test to runs on Mac and Linux without specific date package.

# Why

Issue [!49](https://github.com/qonto/postgresql-partition-manager/issues/49) reported date dependency issue.

# How

- Update docker-compose to start PostgreSQL before bats to avoid false positive error.
- Fix date command in bats

   Replaced all three date -d (GNU-only) calls with a portable format_epoch helper that auto-detects the platform: it uses date -d on GNU/Linux and date -r on macOS/BSD. The detection runs once per call by testing date -d "@0" and branching accordingly. This removes the GNU coreutils dependency for macOS local development without changing behavior on Linux.

# Release

No release