### PR TITLE
Allow test and linter workflow for Pull Request

### DIFF
--- a/.github/workflows/linter.yaml
+++ b/.github/workflows/linter.yaml
@@ -4,6 +4,9 @@ on:  # yamllint disable-line rule:truthy
   push:
     branches:
       - "*"
+  pull_request:
+    branches:
+      - main
 
 permissions:
   contents: read

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -4,6 +4,9 @@ on:  # yamllint disable-line rule:truthy
   push:
     branches:
       - "*"
+  pull_request:
+    branches:
+      - main
 
 permissions:
   contents: read


### PR DESCRIPTION
# Goal

Prevent test and linter failures after contribution on `main` branch

# Why

The linter and test workflows currently do not run on pull requests because they would expose Qonto's runners to the execution of untrusted code.

As a result, valid contributions to PostgreSQL Partition Manager do not benefit from automated linting and test checks. GitHub provides a dedicated setting for public repositories that allows maintainers to control workflow execution for contributors outside the organization. See [Controlling changes from forks to workflows in public repositories](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/enabling-features-for-your-repository/managing-github-actions-settings-for-a-repository#controlling-changes-from-forks-to-workflows-in-public-repositories).

By enabling the **"Require approval for all external contributors"** setting in the GitHub repository and merging this PR, maintainers will be able to manually approve workflow runs before any GitHub Actions are executed. See [Approving workflow runs on a pull request from a public fork](https://docs.github.com/en/actions/how-tos/manage-workflow-runs/approve-runs-from-forks#approving-workflow-runs-on-a-pull-request-from-a-public-fork).
# How

- Allow test and linter worklow to run on pull request

# Release plan

- [ ] Set [Require approval for all external contributors](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/enabling-features-for-your-repository/managing-github-actions-settings-for-a-repository#controlling-changes-from-forks-to-workflows-in-public-repositories) on Github project by PPM Github owner
- [ ] Merge this PR