### PR TITLE
fix(ci): run lint and unitests on an PR open

### DIFF
--- a/.github/workflows/linter.yaml
+++ b/.github/workflows/linter.yaml
@@ -1,6 +1,7 @@
 ---
 name: linter
 on:  # yamllint disable-line rule:truthy
+  pull_request:
   push:
     branches:
       - "*"

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,6 +1,7 @@
 ---
 name: unittest
 on:  # yamllint disable-line rule:truthy
+  pull_request:
   push:
     branches:
       - "*"


### PR DESCRIPTION
for some reason, if you open a PR, you may end up dealing with issues from another PR opened. I don't know why or how. This aims to fix this behavior.